### PR TITLE
Fix Bug 1132086: Changes position to display position.location_filter

### DIFF
--- a/careers/careers/templates/careers/position.html
+++ b/careers/careers/templates/careers/position.html
@@ -19,7 +19,7 @@
             <dt class="job-post-team-head">Team:</dt>
             <dd class="job-post-team">{{ position.category.name }}</dd>
             <dt class="job-post-location-head">Locations:</dt>
-            <dd class="job-post-location">{{ position.location|default('All', True) }}</dd>
+            <dd class="job-post-location">{{ position.location_filter|default('All', True) }}</dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
This pr changes the position template to display the value of location filter. This is the same value displayed in the listings page.

@Osmose Everything locally tests our fine, however is there some plumbing that this may clog?