### PR TITLE
Clock changes

### DIFF
--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 import datetime
+import os
+import sys
 
 from django.core.management import call_command
 from django.conf import settings
@@ -36,7 +38,10 @@ class scheduled_job(object):
             self.log('finished successfully')
 
     def log(self, message):
-        print('Clock job {0}: {1}'.format(self.name, message))
+        msg = '[{}] Clock job {}@{}: {}'.format(
+            datetime.datetime.utcnow(), self.name,
+            os.getenv('DEIS_APP', 'default_app'), message)
+        print(msg, file=sys.stderr)
 
 
 def ping_dms(function):
@@ -47,6 +52,7 @@ def ping_dms(function):
             utcnow = datetime.datetime.utcnow()
             payload = {'m': 'Run {} on {}'.format(function.__name__, utcnow.isoformat())}
             requests.get(settings.DEAD_MANS_SNITCH_URL, params=payload)
+    _ping.__name__ = function.__name__
     return _ping
 
 

--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -56,7 +56,7 @@ def ping_dms(function):
     return _ping
 
 
-@scheduled_job('interval', minutes=3)
+@scheduled_job('interval', minutes=10, max_instances=1, coalesce=True)
 @ping_dms
 def job_syncjobvite():
     call_command('syncjobvite')


### PR DESCRIPTION
@jgmize this brings more logging to the table including the name of the deis_app that the logs come from. 

I added `max_instances=1, coalesce=True` to ensure that there are no multiple instances running. 

Interestingly prints to `stdout` do not appear in `docker logs` or papertrail, so I'm using `stderr`

cc @pmclanahan 