### PR TITLE
Manually close db connections after call_command.

### DIFF
--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -5,6 +5,7 @@ import sys
 
 from django.core.management import call_command
 from django.conf import settings
+from django.db import connections
 
 import requests
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -60,7 +61,9 @@ def ping_dms(function):
 @ping_dms
 def job_syncjobvite():
     call_command('syncjobvite')
-
+    # Django won't close db connections after call_command. Close them manually
+    # to prevent errors in case the DB goes away, e.g. during a failover event.
+    connections.close_all()
 
 def run():
     try:


### PR DESCRIPTION
Django won't close db connections after a call_command. This can result
in 'MySQL has gone away' errors in the case of a failover event in RDS.

Interestingly this only happens when using call_command. If you're
executing management commands from the shell Django cleans up the
connections. Probably a Django bug.

https://github.com/django/django/commit/1d24f073e65113c8c6d974db0504ef7d083809f7